### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -242,7 +242,7 @@ class TileGeneration:
                 for r in grid['resolutions']:
                     if r * scale % 1 != 0.0:
                         logger.error(
-                            "The resolution {0!s} * resolution_scale {1:d} is not an integer.".format(
+                            "The resolution {} * resolution_scale {} is not an integer.".format(
                                 r, scale
                             )
                         )
@@ -266,7 +266,7 @@ class TileGeneration:
                         '+x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 ' \
                         '+units=m +no_defs'
                 else:  # pragma: no cover
-                    grid['proj4_literal'] = '+init={0!s}'.format(grid['srs'])
+                    grid['proj4_literal'] = '+init={}'.format(grid['srs'])
 
             scale = grid['resolution_scale']
             grid['obj'] = FreeTileGrid(
@@ -569,7 +569,7 @@ class TileGeneration:
         if self.layer is None:
             exit("A layer must be specified.")
         if 'sqs' not in self.layer:
-            exit("The layer '{0!s}' hasn't any configured queue".format(self.layer['name']))
+            exit("The layer '{}' hasn't any configured queue".format(self.layer['name']))
         connection = boto.sqs.connect_to_region(self.layer['sqs']['region'])
         queue = connection.get_queue(self.layer['sqs']['queue'])
         queue.set_message_class(JSONMessage)
@@ -603,8 +603,8 @@ class TileGeneration:
             for g in layer['geoms']:
                 connection = psycopg2.connect(g['connection'])
                 cursor = connection.cursor()
-                sql = 'SELECT ST_AsBinary(geom) FROM (SELECT {0!s}) AS g'.format(g['sql'])
-                logger.info('Execute SQL: {0!s}.'.format(sql))
+                sql = 'SELECT ST_AsBinary(geom) FROM (SELECT {}) AS g'.format(g['sql'])
+                logger.info('Execute SQL: {}.'.format(sql))
                 cursor.execute(sql)
                 geoms = [loads_wkb(binary_type(r[0])) for r in cursor.fetchall()]
                 geom = cascaded_union(geoms)
@@ -656,7 +656,7 @@ class TileGeneration:
                 variables = dict()
                 variables.update(tile.__dict__)
                 variables.update(tile.tilecoord.__dict__)
-                sys.stdout.write("{tilecoord!s}          \r".format(**variables))
+                sys.stdout.write("{tilecoord}          \r".format(**variables))
                 sys.stdout.flush()
                 return tile
             self.imap(log_tiles)
@@ -717,7 +717,7 @@ class TileGeneration:
                 ),
                 'a'
             )
-            self.error_file.write("# [{0!s}] Start the layer '{1!s}' generation\n".format(time, layer))
+            self.error_file.write("# [{}] Start the layer '{}' generation\n".format(time, layer))
 
     def log_tiles_error(self, tilecoord=None, message=None):
         if 'error_file' in self.config['generation']:
@@ -725,10 +725,10 @@ class TileGeneration:
             if self.error_file is None:  # pragma: no cover
                 raise "Missing error file"
 
-            tilecoord = "" if tilecoord is None else "{0!s} ".format(tilecoord)
-            message = "" if message is None else " {0!s}".format(message)
+            tilecoord = "" if tilecoord is None else "{} ".format(tilecoord)
+            message = "" if message is None else " {}".format(message)
 
-            self.error_file.write('{0!s}# [{1!s}]{2!s}\n'.format(tilecoord, time, message.replace('\n', ' ')))
+            self.error_file.write('{}# [{}]{}\n'.format(tilecoord, time, message.replace('\n', ' ')))
 
     def add_error_filters(self):
         self.imap(LogErrors(
@@ -810,7 +810,7 @@ class TileGeneration:
                 extent = self.geoms[zoom].bounds
 
                 if len(extent) == 0:
-                    logger.warn("bounds empty for zoom {0:d}".format(zoom))
+                    logger.warn("bounds empty for zoom {}".format(zoom))
                 else:
                     minx, miny, maxx, maxy = extent
                     px_buffer = self.layer['px_buffer']
@@ -863,7 +863,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.get_one(tile)
                     if time_message:
-                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
+                        logger.info("{} in {}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -885,7 +885,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.put_one(tile)
                     if time_message:
-                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
+                        logger.info("{} in {}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -907,7 +907,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.delete_one(tile)
                     if time_message:
-                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
+                        logger.info("{} in {}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -929,7 +929,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = tile_filter(tile)
                     if time_message:  # pragma: no cover
-                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
+                        logger.info("{} in {}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -952,7 +952,7 @@ class TileGeneration:
                         n = datetime.now()
                         t = tile_filter(tile)
                         if time_message:
-                            logger.debug("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
+                            logger.debug("{} in {}".format(time_message, str(datetime.now() - n)))
                         return t
                     except GeneratorExit as e:  # pragma: no cover
                         raise e
@@ -1026,7 +1026,7 @@ class HashDropper:
                         self.store.delete_one(Tile(tilecoord))
                 else:
                     self.store.delete_one(tile)
-            logger.info("The tile {0!s} is dropped".format(str(tile.tilecoord)))
+            logger.info("The tile {} is dropped".format(str(tile.tilecoord)))
             if hasattr(tile, 'metatile'):
                 tile.metatile.elapsed_togenerate -= 1
                 if tile.metatile.elapsed_togenerate == 0 and self.queue_store is not None:
@@ -1061,10 +1061,10 @@ class HashLogger:
             elif px != ref:
                 exit("Error: image is not uniform.")
 
-        print("""Tile: {0!s}
-    {1!s}:
-        size: {2:d}
-        hash: {3!s}""".format(str(tile.tilecoord), self.block, len(tile.data), sha1(tile.data).hexdigest()))
+        print("""Tile: {}
+    {}:
+        size: {}
+        hash: {}""".format(str(tile.tilecoord), self.block, len(tile.data), sha1(tile.data).hexdigest()))
         return tile
 
 
@@ -1134,11 +1134,11 @@ def quote(arg):
     if ' ' in arg:
         if "'" in arg:
             if '"' in arg:
-                return "'{0!s}'".format(arg.replace("'", "\\'"))
+                return "'{}'".format(arg.replace("'", "\\'"))
             else:
-                return '"{0!s}"'.format(arg)
+                return '"{}"'.format(arg)
         else:
-            return "'{0!s}'".format(arg)
+            return "'{}'".format(arg)
     elif arg == '':
         return "''"
     else:
@@ -1202,7 +1202,7 @@ class Process:
                     'y': tile.tilecoord.y,
                     'z': tile.tilecoord.z
                 }
-                logger.info('process: {0!s}'.format(command))
+                logger.info('process: {}'.format(command))
                 code = subprocess.call(command, shell=True)
                 if code != 0:  # pragma: no cover
                     tile.error = "Command '%s' on tile %s " \
@@ -1237,4 +1237,4 @@ class TilesFileStore:
                 try:
                     yield Tile(parse_tilecoord(line))
                 except ValueError as e:  # pragma: no cover
-                    logger.error("A tile '{0!s}' is not in the format 'z/x/y' or z/x/y:+n/+n\n{1!r}".format(line, e))
+                    logger.error("A tile '{}' is not in the format 'z/x/y' or z/x/y:+n/+n\n{1!r}".format(line, e))

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -241,7 +241,7 @@ class TileGeneration:
                 scale = grid['resolution_scale']
                 for r in grid['resolutions']:
                     if r * scale % 1 != 0.0:
-                        logger.error("The resolution %s * resolution_scale %i is not an integer." % (r, scale))
+                        logger.error("The resolution {0!s} * resolution_scale {1:d} is not an integer.".format(r, scale))
                         error = True
             else:
                 grid['resolution_scale'] = self._resolution_scale(grid['resolutions'])
@@ -262,7 +262,7 @@ class TileGeneration:
                         '+x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 ' \
                         '+units=m +no_defs'
                 else:  # pragma: no cover
-                    grid['proj4_literal'] = '+init=%s' % grid['srs']
+                    grid['proj4_literal'] = '+init={0!s}'.format(grid['srs'])
 
             scale = grid['resolution_scale']
             grid['obj'] = FreeTileGrid(
@@ -565,7 +565,7 @@ class TileGeneration:
         if self.layer is None:
             exit("A layer must be specified.")
         if 'sqs' not in self.layer:
-            exit("The layer '%s' hasn't any configured queue" % self.layer['name'])
+            exit("The layer '{0!s}' hasn't any configured queue".format(self.layer['name']))
         connection = boto.sqs.connect_to_region(self.layer['sqs']['region'])
         queue = connection.get_queue(self.layer['sqs']['queue'])
         queue.set_message_class(JSONMessage)
@@ -599,8 +599,8 @@ class TileGeneration:
             for g in layer['geoms']:
                 connection = psycopg2.connect(g['connection'])
                 cursor = connection.cursor()
-                sql = 'SELECT ST_AsBinary(geom) FROM (SELECT %s) AS g' % g['sql']
-                logger.info('Execute SQL: %s.' % sql)
+                sql = 'SELECT ST_AsBinary(geom) FROM (SELECT {0!s}) AS g'.format(g['sql'])
+                logger.info('Execute SQL: {0!s}.'.format(sql))
                 cursor.execute(sql)
                 geoms = [loads_wkb(binary_type(r[0])) for r in cursor.fetchall()]
                 geom = cascaded_union(geoms)
@@ -652,7 +652,7 @@ class TileGeneration:
                 variables = dict()
                 variables.update(tile.__dict__)
                 variables.update(tile.tilecoord.__dict__)
-                sys.stdout.write("%(tilecoord)s          \r" % variables)
+                sys.stdout.write("{tilecoord!s}          \r".format(**variables))
                 sys.stdout.flush()
                 return tile
             self.imap(log_tiles)
@@ -713,7 +713,7 @@ class TileGeneration:
                 ),
                 'a'
             )
-            self.error_file.write("# [%s] Start the layer '%s' generation\n" % (time, layer))
+            self.error_file.write("# [{0!s}] Start the layer '{1!s}' generation\n".format(time, layer))
 
     def log_tiles_error(self, tilecoord=None, message=None):
         if 'error_file' in self.config['generation']:
@@ -721,10 +721,10 @@ class TileGeneration:
             if self.error_file is None:  # pragma: no cover
                 raise "Missing error file"
 
-            tilecoord = "" if tilecoord is None else "%s " % tilecoord
-            message = "" if message is None else " %s" % message
+            tilecoord = "" if tilecoord is None else "{0!s} ".format(tilecoord)
+            message = "" if message is None else " {0!s}".format(message)
 
-            self.error_file.write('%s# [%s]%s\n' % (tilecoord, time, message.replace('\n', ' ')))
+            self.error_file.write('{0!s}# [{1!s}]{2!s}\n'.format(tilecoord, time, message.replace('\n', ' ')))
 
     def add_error_filters(self):
         self.imap(LogErrors(
@@ -806,7 +806,7 @@ class TileGeneration:
                 extent = self.geoms[zoom].bounds
 
                 if len(extent) == 0:
-                    logger.warn("bounds empty for zoom %i" % zoom)
+                    logger.warn("bounds empty for zoom {0:d}".format(zoom))
                 else:
                     minx, miny, maxx, maxy = extent
                     px_buffer = self.layer['px_buffer']
@@ -859,7 +859,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.get_one(tile)
                     if time_message:
-                        logger.info("%s in %s" % (time_message, str(datetime.now() - n)))
+                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -881,7 +881,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.put_one(tile)
                     if time_message:
-                        logger.info("%s in %s" % (time_message, str(datetime.now() - n)))
+                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -903,7 +903,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = store.delete_one(tile)
                     if time_message:
-                        logger.info("%s in %s" % (time_message, str(datetime.now() - n)))
+                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -925,7 +925,7 @@ class TileGeneration:
                     n = datetime.now()
                     t = tile_filter(tile)
                     if time_message:  # pragma: no cover
-                        logger.info("%s in %s" % (time_message, str(datetime.now() - n)))
+                        logger.info("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
                     return t
                 except GeneratorExit as e:  # pragma: no cover
                     raise e
@@ -948,7 +948,7 @@ class TileGeneration:
                         n = datetime.now()
                         t = tile_filter(tile)
                         if time_message:
-                            logger.debug("%s in %s" % (time_message, str(datetime.now() - n)))
+                            logger.debug("{0!s} in {1!s}".format(time_message, str(datetime.now() - n)))
                         return t
                     except GeneratorExit as e:  # pragma: no cover
                         raise e
@@ -1022,7 +1022,7 @@ class HashDropper:
                         self.store.delete_one(Tile(tilecoord))
                 else:
                     self.store.delete_one(tile)
-            logger.info("The tile %s is dropped" % str(tile.tilecoord))
+            logger.info("The tile {0!s} is dropped".format(str(tile.tilecoord)))
             if hasattr(tile, 'metatile'):
                 tile.metatile.elapsed_togenerate -= 1
                 if tile.metatile.elapsed_togenerate == 0 and self.queue_store is not None:
@@ -1057,10 +1057,10 @@ class HashLogger:
             elif px != ref:
                 exit("Error: image is not uniform.")
 
-        print("""Tile: %s
-    %s:
-        size: %i
-        hash: %s""" % (str(tile.tilecoord), self.block, len(tile.data), sha1(tile.data).hexdigest()))
+        print("""Tile: {0!s}
+    {1!s}:
+        size: {2:d}
+        hash: {3!s}""".format(str(tile.tilecoord), self.block, len(tile.data), sha1(tile.data).hexdigest()))
         return tile
 
 
@@ -1116,9 +1116,9 @@ class DropEmpty:
 
     def __call__(self, tile):
         if not tile or not tile.data:  # pragma: no cover
-            logger.error("The tile: %(tilecoord)s is empty" % {
+            logger.error("The tile: {tilecoord!s} is empty".format(**{
                 'tilecoord': tile.tilecoord if tile else 'not defined'
-            })
+            }))
             if 'error_file' in self.gene.config['generation'] and tile:
                 self.gene.log_tiles_error(tilecoord=tile.tilecoord, message='The tile is empty')
             return None
@@ -1130,11 +1130,11 @@ def quote(arg):
     if ' ' in arg:
         if "'" in arg:
             if '"' in arg:
-                return "'%s'" % arg.replace("'", "\\'")
+                return "'{0!s}'".format(arg.replace("'", "\\'"))
             else:
-                return '"%s"' % arg
+                return '"{0!s}"'.format(arg)
         else:
-            return "'%s'" % arg
+            return "'{0!s}'".format(arg)
     elif arg == '':
         return "''"
     else:
@@ -1198,7 +1198,7 @@ class Process:
                     'y': tile.tilecoord.y,
                     'z': tile.tilecoord.z
                 }
-                logger.info('process: %s' % command)
+                logger.info('process: {0!s}'.format(command))
                 code = subprocess.call(command, shell=True)
                 if code != 0:  # pragma: no cover
                     tile.error = "Command '%s' on tile %s " \
@@ -1233,4 +1233,4 @@ class TilesFileStore:
                 try:
                     yield Tile(parse_tilecoord(line))
                 except ValueError as e:  # pragma: no cover
-                    logger.error("A tile '%s' is not in the format 'z/x/y' or z/x/y:+n/+n\n%r" % (line, e))
+                    logger.error("A tile '{0!s}' is not in the format 'z/x/y' or z/x/y:+n/+n\n{1!r}".format(line, e))

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -241,7 +241,11 @@ class TileGeneration:
                 scale = grid['resolution_scale']
                 for r in grid['resolutions']:
                     if r * scale % 1 != 0.0:
-                        logger.error("The resolution {0!s} * resolution_scale {1:d} is not an integer.".format(r, scale))
+                        logger.error(
+                            "The resolution {0!s} * resolution_scale {1:d} is not an integer.".format(
+                                r, scale
+                            )
+                        )
                         error = True
             else:
                 grid['resolution_scale'] = self._resolution_scale(grid['resolutions'])

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -128,8 +128,7 @@ def _get(path, cache):
 def _validate_generate_wmts_capabilities(gene, cache):
     if 'http_url' not in cache and 'http_urls' not in cache:  # pragma: no cover
         logger.error(
-            "The attribute 'http_url' or 'http_urls' is required in the object {0!s}.".format(
-            ('cache[{0!s}]'.format(cache['name'])))
+            "The attribute 'http_url' or 'http_urls' is required in the object cache[{0!s}].".format(cache['name'])
         )
         exit(1)
 
@@ -312,7 +311,7 @@ def _generate_apache_config(gene):
                         'region': cache['region'],
                         'bucket': cache['bucket'],
                         'folder': folder
-                })
+                    })
                 f.write(
                     """
     <Proxy {tiles_url!s}*>

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -128,7 +128,7 @@ def _get(path, cache):
 def _validate_generate_wmts_capabilities(gene, cache):
     if 'http_url' not in cache and 'http_urls' not in cache:  # pragma: no cover
         logger.error(
-            "The attribute 'http_url' or 'http_urls' is required in the object cache[{0!s}].".format(cache['name'])
+            "The attribute 'http_url' or 'http_urls' is required in the object cache[{}].".format(cache['name'])
         )
         exit(1)
 
@@ -158,7 +158,7 @@ def _generate_wmts_capabilities(gene):
         if 'legend_mime' in layer and 'legend_extention' in layer and 'legends' not in layer:
             layer['legends'] = []
             for zoom, resolution in enumerate(layer['grid_ref']['resolutions']):
-                path = '/'.join(['1.0.0', layer['name'], layer['wmts_style'], 'legend{0!s}.{1!s}'.format(
+                path = '/'.join(['1.0.0', layer['name'], layer['wmts_style'], 'legend{}.{}'.format(
                     zoom,
                     layer['legend_extention']
                 )])
@@ -178,7 +178,7 @@ def _generate_wmts_capabilities(gene):
                         new_legend['width'] = pil_img.size[0]
                         new_legend['height'] = pil_img.size[1]
                     except:  # pragma: nocover
-                        logger.warn("Unable to read legend image '{0!s}', with '{1!r}'".format(path, img))
+                        logger.warn("Unable to read legend image '{}', with '{1!r}'".format(path, img))
                     previous_legend = new_legend
                 previous_resolution = resolution
 
@@ -244,7 +244,7 @@ def _generate_legend_images(gene):
                         previous_hash = new_hash
                         _send(
                             result,
-                            '1.0.0/{0!s}/{1!s}/legend{2!s}.{3!s}'.format(
+                            '1.0.0/{}/{}/legend{}.{}'.format(
                                 layer['name'],
                                 layer['wmts_style'],
                                 zoom,
@@ -292,14 +292,14 @@ def _generate_apache_config(gene):
             f.write("""
     <Location {location!s}>
         ExpiresActive on
-        ExpiresDefault "now plus {expires:d} hours"
+        ExpiresDefault "now plus {expires} hours"
     {headers!s}
     </Location>
     """.format(**{
                 'location': gene.config['apache']['location'],
                 'expires': gene.config['apache']['expires'],
                 'headers': ''.join([
-                    '    Header set {0!s} "{1!s}"'.format(*h)
+                    '    Header set {} "{}"'.format(*h)
                     for h in gene.config['apache'].get('headers', {
                         'Cache-Control': 'max-age=864000, public'
                     }).items()
@@ -333,7 +333,7 @@ def _generate_apache_config(gene):
                         'location': gene.config['apache']['location'],
                         'files_folder': folder,
                         'headers': ''.join([
-                            "    Header set {0!s} '{1!s}'".format(*h)
+                            "    Header set {} '{}'".format(*h)
                             for h in gene.config['apache'].get('headers', {
                                 'Cache-Control': 'max-age=864000, public'
                             }).items()
@@ -368,7 +368,7 @@ def _generate_apache_config(gene):
                                 'layer': layer['name'],
                                 'token_regex': token_regex,
                                 'dimensions_re': ''.join(['/' + token_regex for e in range(dim)]),
-                                'dimensions_rep': ''.join(['/${0:d}'.format((e + 2)) for e in range(dim)]),
+                                'dimensions_rep': ''.join(['/${}'.format((e + 2)) for e in range(dim)]),
                                 'tilematrixset': dim + 2,
                                 'final': dim + 3,
                                 'zoom': layer['grid_ref']['resolutions'].index(r)

--- a/tilecloud_chain/copy_.py
+++ b/tilecloud_chain/copy_.py
@@ -57,14 +57,14 @@ class Copy:
         gene.consume()
         if not options.quiet:
             print(
-                """The tile {0!s} of layer '{1!s}' is finish
-Nb {2!s} tiles: {3:d}
-Nb errored tiles: {4:d}
-Nb dropped tiles: {5:d}
-Total time: {6!s}
-Total size: {7!s}
-Time per tile: {8:d} ms
-Size per tile: {9:d} o
+                """The tile {} of layer '{}' is finish
+Nb {} tiles: {}
+Nb errored tiles: {}
+Nb dropped tiles: {}
+Total time: {}
+Total size: {}
+Time per tile: {} ms
+Size per tile: {} o
 """.format(
                     task_name,
                     gene.layer['name'],

--- a/tilecloud_chain/copy_.py
+++ b/tilecloud_chain/copy_.py
@@ -57,15 +57,15 @@ class Copy:
         gene.consume()
         if not options.quiet:
             print(
-                """The tile %s of layer '%s' is finish
-Nb %s tiles: %i
-Nb errored tiles: %i
-Nb dropped tiles: %i
-Total time: %s
-Total size: %s
-Time per tile: %i ms
-Size per tile: %i o
-""" % (
+                """The tile {0!s} of layer '{1!s}' is finish
+Nb {2!s} tiles: {3:d}
+Nb errored tiles: {4:d}
+Nb dropped tiles: {5:d}
+Total time: {6!s}
+Total size: {7!s}
+Time per tile: {8:d} ms
+Size per tile: {9:d} o
+""".format(
                     task_name,
                     gene.layer['name'],
                     task_name,

--- a/tilecloud_chain/cost.py
+++ b/tilecloud_chain/cost.py
@@ -59,7 +59,9 @@ def main():
         print('Total generation time: {0!s} [d h:mm:ss]'.format((duration_format(all_time))))
         print('Total generation cost: {0:0.2f} [$]'.format(all_price))
     print("")
-    print('S3 Storage: {0:0.2f} [$/month]'.format((all_size * gene.config['cost']['s3']['storage'] / (1024.0 * 1024 * 1024))))
+    print('S3 Storage: {0:0.2f} [$/month]'.format(
+        all_size * gene.config['cost']['s3']['storage'] / (1024.0 * 1024 * 1024)
+    ))
     print('S3 get: {0:0.2f} [$/month]'.format((
         gene.config['cost']['s3']['get'] * gene.config['cost']['request_per_layers'] / 10000.0 +
         gene.config['cost']['s3']['download'] * gene.config['cost']['request_per_layers'] * tile_size))

--- a/tilecloud_chain/cost.py
+++ b/tilecloud_chain/cost.py
@@ -44,7 +44,7 @@ def main():
         all_price = 0
         for layer in gene.config['generation']['default_layers']:
             print("")
-            print("===== {0!s} =====".format(layer))
+            print("===== {} =====".format(layer))
             gene.set_layer(layer, options)
             (size, time, price, tiles) = _calculate_cost(gene, options)
             tile_size += gene.layer['cost']['tile_size'] / (1024.0 * 1024)
@@ -55,8 +55,8 @@ def main():
 
         print("")
         print("===== GLOBAL =====")
-        print("Total number of tiles: {0:d}".format(all_tiles))
-        print('Total generation time: {0!s} [d h:mm:ss]'.format((duration_format(all_time))))
+        print("Total number of tiles: {}".format(all_tiles))
+        print('Total generation time: {} [d h:mm:ss]'.format((duration_format(all_time))))
         print('Total generation cost: {0:0.2f} [$]'.format(all_price))
     print("")
     print('S3 Storage: {0:0.2f} [$/month]'.format(
@@ -84,7 +84,7 @@ def _calculate_cost(gene, options):
             if 'min_resolution_seed' in gene.layer and resolution < gene.layer['min_resolution_seed']:
                 continue
 
-            print("Calculate zoom {0:d}.".format(zoom))
+            print("Calculate zoom {}.".format(zoom))
 
             px_buffer = gene.layer['px_buffer'] + \
                 gene.layer['meta_buffer'] if meta else 0
@@ -128,7 +128,7 @@ def _calculate_cost(gene, options):
                 if tile.tilecoord.z in nb_tiles:
                     nb_tiles[tile.tilecoord.z] += 1
                 else:
-                    print("Calculate zoom {0:d}.".format(tile.tilecoord.z))
+                    print("Calculate zoom {}.".format(tile.tilecoord.z))
                     nb_tiles[tile.tilecoord.z] = 1
             return tile
         gene.imap(count_tile)
@@ -138,7 +138,7 @@ def _calculate_cost(gene, options):
     times = {}
     print('')
     for z in nb_metatiles:
-        print("{0:d} meta tiles in zoom {1:d}.".format(nb_metatiles[z], z))
+        print("{} meta tiles in zoom {}.".format(nb_metatiles[z], z))
         times[z] = gene.layer['cost']['metatile_generation_time'] * nb_metatiles[z]
 
     price = 0
@@ -147,7 +147,7 @@ def _calculate_cost(gene, options):
     all_tiles = 0
     for z in nb_tiles:
         print('')
-        print("{0:d} tiles in zoom {1:d}.".format(nb_tiles[z], z))
+        print("{} tiles in zoom {}.".format(nb_tiles[z], z))
         all_tiles += nb_tiles[z]
         if meta:
             time = times[z] + gene.layer['cost']['tile_generation_time'] * nb_tiles[z]
@@ -158,7 +158,7 @@ def _calculate_cost(gene, options):
 
         all_time += time
         td = timedelta(milliseconds=time)
-        print("Time to generate: {0!s} [d h:mm:ss]".format((duration_format(td))))
+        print("Time to generate: {} [d h:mm:ss]".format((duration_format(td))))
         c = gene.config['cost']['s3']['put'] * nb_tiles[z] / 1000.0
         price += c
         print('S3 PUT: {0:0.2f} [$]'.format(c))
@@ -174,8 +174,8 @@ def _calculate_cost(gene, options):
 
     print("")
     td = timedelta(milliseconds=all_time)
-    print("Number of tiles: {0:d}".format(all_tiles))
-    print('Generation time: {0!s} [d h:mm:ss]'.format((duration_format(td))))
+    print("Number of tiles: {}".format(all_tiles))
+    print('Generation time: {} [d h:mm:ss]'.format((duration_format(td))))
     print('Generation cost: {0:0.2f} [$]'.format(price))
 
     return (all_size, td, price, all_tiles)

--- a/tilecloud_chain/cost.py
+++ b/tilecloud_chain/cost.py
@@ -44,7 +44,7 @@ def main():
         all_price = 0
         for layer in gene.config['generation']['default_layers']:
             print("")
-            print("===== %s =====" % layer)
+            print("===== {0!s} =====".format(layer))
             gene.set_layer(layer, options)
             (size, time, price, tiles) = _calculate_cost(gene, options)
             tile_size += gene.layer['cost']['tile_size'] / (1024.0 * 1024)
@@ -55,14 +55,14 @@ def main():
 
         print("")
         print("===== GLOBAL =====")
-        print("Total number of tiles: %i" % all_tiles)
-        print('Total generation time: %s [d h:mm:ss]' % (duration_format(all_time)))
-        print('Total generation cost: %0.2f [$]' % all_price)
+        print("Total number of tiles: {0:d}".format(all_tiles))
+        print('Total generation time: {0!s} [d h:mm:ss]'.format((duration_format(all_time))))
+        print('Total generation cost: {0:0.2f} [$]'.format(all_price))
     print("")
-    print('S3 Storage: %0.2f [$/month]' % (all_size * gene.config['cost']['s3']['storage'] / (1024.0 * 1024 * 1024)))
-    print('S3 get: %0.2f [$/month]' % (
+    print('S3 Storage: {0:0.2f} [$/month]'.format((all_size * gene.config['cost']['s3']['storage'] / (1024.0 * 1024 * 1024))))
+    print('S3 get: {0:0.2f} [$/month]'.format((
         gene.config['cost']['s3']['get'] * gene.config['cost']['request_per_layers'] / 10000.0 +
-        gene.config['cost']['s3']['download'] * gene.config['cost']['request_per_layers'] * tile_size)
+        gene.config['cost']['s3']['download'] * gene.config['cost']['request_per_layers'] * tile_size))
     )
 #    if 'cloudfront' in gene.config['cost']:
 #        print('CloudFront: %0.2f [$/month]' % ()
@@ -82,7 +82,7 @@ def _calculate_cost(gene, options):
             if 'min_resolution_seed' in gene.layer and resolution < gene.layer['min_resolution_seed']:
                 continue
 
-            print("Calculate zoom %i." % zoom)
+            print("Calculate zoom {0:d}.".format(zoom))
 
             px_buffer = gene.layer['px_buffer'] + \
                 gene.layer['meta_buffer'] if meta else 0
@@ -126,7 +126,7 @@ def _calculate_cost(gene, options):
                 if tile.tilecoord.z in nb_tiles:
                     nb_tiles[tile.tilecoord.z] += 1
                 else:
-                    print("Calculate zoom %i." % tile.tilecoord.z)
+                    print("Calculate zoom {0:d}.".format(tile.tilecoord.z))
                     nb_tiles[tile.tilecoord.z] = 1
             return tile
         gene.imap(count_tile)
@@ -136,7 +136,7 @@ def _calculate_cost(gene, options):
     times = {}
     print('')
     for z in nb_metatiles:
-        print("%i meta tiles in zoom %i." % (nb_metatiles[z], z))
+        print("{0:d} meta tiles in zoom {1:d}.".format(nb_metatiles[z], z))
         times[z] = gene.layer['cost']['metatile_generation_time'] * nb_metatiles[z]
 
     price = 0
@@ -145,7 +145,7 @@ def _calculate_cost(gene, options):
     all_tiles = 0
     for z in nb_tiles:
         print('')
-        print("%i tiles in zoom %i." % (nb_tiles[z], z))
+        print("{0:d} tiles in zoom {1:d}.".format(nb_tiles[z], z))
         all_tiles += nb_tiles[z]
         if meta:
             time = times[z] + gene.layer['cost']['tile_generation_time'] * nb_tiles[z]
@@ -156,10 +156,10 @@ def _calculate_cost(gene, options):
 
         all_time += time
         td = timedelta(milliseconds=time)
-        print("Time to generate: %s [d h:mm:ss]" % (duration_format(td)))
+        print("Time to generate: {0!s} [d h:mm:ss]".format((duration_format(td))))
         c = gene.config['cost']['s3']['put'] * nb_tiles[z] / 1000.0
         price += c
-        print('S3 PUT: %0.2f [$]' % c)
+        print('S3 PUT: {0:0.2f} [$]'.format(c))
 
         if 'sqs' in gene.layer:
             if meta:
@@ -168,12 +168,12 @@ def _calculate_cost(gene, options):
                 nb_sqs = nb_tiles[z] * 3
             c = nb_sqs * gene.config['cost']['sqs']['request'] / 1000000.0
             price += c
-            print('SQS usage: %0.2f [$]' % c)
+            print('SQS usage: {0:0.2f} [$]'.format(c))
 
     print("")
     td = timedelta(milliseconds=all_time)
-    print("Number of tiles: %i" % all_tiles)
-    print('Generation time: %s [d h:mm:ss]' % (duration_format(td)))
-    print('Generation cost: %0.2f [$]' % price)
+    print("Number of tiles: {0:d}".format(all_tiles))
+    print('Generation time: {0!s} [d h:mm:ss]'.format((duration_format(td))))
+    print('Generation cost: {0:0.2f} [$]'.format(price))
 
     return (all_size, td, price, all_tiles)

--- a/tilecloud_chain/expiretiles.py
+++ b/tilecloud_chain/expiretiles.py
@@ -81,20 +81,20 @@ def main():
 
     if options.create:
         cursor.execute(
-            "SELECT count(*) FROM pg_tables WHERE schemaname='{0!s}' AND tablename='{1!s}'".format(
+            "SELECT count(*) FROM pg_tables WHERE schemaname='{}' AND tablename='{}'".format(
                 options.schema, options.table
             )
         )
         if cursor.fetchone()[0] == 0:
-            cursor.execute('CREATE TABLE IF NOT EXISTS "{0!s}"."{1!s}" (id serial)'.format(
+            cursor.execute('CREATE TABLE IF NOT EXISTS "{}"."{}" (id serial)'.format(
                 options.schema, options.table
             ))
-            cursor.execute("SELECT AddGeometryColumn('{0!s}', '{1!s}', '{2!s}', {3!s}, 'MULTIPOLYGON', 2)".format(
+            cursor.execute("SELECT AddGeometryColumn('{}', '{}', '{}', {}, 'MULTIPOLYGON', 2)".format(
                 options.schema, options.table, options.column, options.srid
             ))
 
     if options.delete:
-        cursor.execute('DELETE FROM "{0!s}"'.format((options.table)))
+        cursor.execute('DELETE FROM "{}"'.format((options.table)))
 
     geoms = []
     grid = QuadTileGrid(
@@ -122,13 +122,13 @@ def main():
     if options.simplify > 0:
         geom.simplify(options.simplify)
 
-    sql_geom = "ST_GeomFromText('{0!s}', 3857)".format(geom.wkt)
+    sql_geom = "ST_GeomFromText('{}', 3857)".format(geom.wkt)
     if options.srid <= 0:
-        sql_geom = "ST_GeomFromText('{0!s}')".format(geom.wkt)  # pragma: no cover
+        sql_geom = "ST_GeomFromText('{}')".format(geom.wkt)  # pragma: no cover
     elif options.srid != 3857:
-        sql_geom = 'ST_Transform({0!s}, {1:d})'.format(sql_geom, options.srid)
+        sql_geom = 'ST_Transform({}, {})'.format(sql_geom, options.srid)
 
-    cursor.execute('INSERT INTO "{0!s}" ("{1!s}") VALUES ({2!s})'.format(
+    cursor.execute('INSERT INTO "{}" ("{}") VALUES ({})'.format(
         options.table, options.column, sql_geom
     ))
     connection.commit()

--- a/tilecloud_chain/expiretiles.py
+++ b/tilecloud_chain/expiretiles.py
@@ -81,20 +81,20 @@ def main():
 
     if options.create:
         cursor.execute(
-            "SELECT count(*) FROM pg_tables WHERE schemaname='%s' AND tablename='%s'" % (
-                options.schema, options.table,
+            "SELECT count(*) FROM pg_tables WHERE schemaname='{0!s}' AND tablename='{1!s}'".format(
+                options.schema, options.table
             )
         )
         if cursor.fetchone()[0] == 0:
-            cursor.execute('CREATE TABLE IF NOT EXISTS "%s"."%s" (id serial)' % (
-                options.schema, options.table,
+            cursor.execute('CREATE TABLE IF NOT EXISTS "{0!s}"."{1!s}" (id serial)'.format(
+                options.schema, options.table
             ))
-            cursor.execute("SELECT AddGeometryColumn('%s', '%s', '%s', %s, 'MULTIPOLYGON', 2)" % (
-                options.schema, options.table, options.column, options.srid,
+            cursor.execute("SELECT AddGeometryColumn('{0!s}', '{1!s}', '{2!s}', {3!s}, 'MULTIPOLYGON', 2)".format(
+                options.schema, options.table, options.column, options.srid
             ))
 
     if options.delete:
-        cursor.execute('DELETE FROM "%s"' % (options.table))
+        cursor.execute('DELETE FROM "{0!s}"'.format((options.table)))
 
     geoms = []
     grid = QuadTileGrid(
@@ -122,13 +122,13 @@ def main():
     if options.simplify > 0:
         geom.simplify(options.simplify)
 
-    sql_geom = "ST_GeomFromText('%s', 3857)" % geom.wkt
+    sql_geom = "ST_GeomFromText('{0!s}', 3857)".format(geom.wkt)
     if options.srid <= 0:
-        sql_geom = "ST_GeomFromText('%s')" % geom.wkt  # pragma: no cover
+        sql_geom = "ST_GeomFromText('{0!s}')".format(geom.wkt)  # pragma: no cover
     elif options.srid != 3857:
-        sql_geom = 'ST_Transform(%s, %i)' % (sql_geom, options.srid)
+        sql_geom = 'ST_Transform({0!s}, {1:d})'.format(sql_geom, options.srid)
 
-    cursor.execute('INSERT INTO "%s" ("%s") VALUES (%s)' % (
+    cursor.execute('INSERT INTO "{0!s}" ("{1!s}") VALUES ({2!s})'.format(
         options.table, options.column, sql_geom
     ))
     connection.commit()

--- a/tilecloud_chain/format.py
+++ b/tilecloud_chain/format.py
@@ -5,9 +5,9 @@ def size_format(number):
     for unit in ['o', 'Kio', 'Mio', 'Gio', 'Tio']:
         if number < 1024.0:
             if number < 10:
-                return "%.1f %s" % (number, unit)
+                return "{0:.1f} {1!s}".format(number, unit)
             else:
-                return "%.0f %s" % (number, unit)
+                return "{0:.0f} {1!s}".format(number, unit)
         number /= 1024.0
 
 
@@ -15,6 +15,6 @@ def duration_format(duration):
     hours, remainder = divmod(duration.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
     if duration.days > 0:
-        return '%i %i:%02i:%02i' % (duration.days, hours, minutes, seconds)
+        return '{0:d} {1:d}:{2:02d}:{3:02d}'.format(duration.days, hours, minutes, seconds)
     else:
-        return '%i:%02i:%02i' % (hours, minutes, seconds)
+        return '{0:d}:{1:02d}:{2:02d}'.format(hours, minutes, seconds)

--- a/tilecloud_chain/format.py
+++ b/tilecloud_chain/format.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 
 
+def default_int(number_array):
+    return [
+        int(n) if n % 1 == 0 else n
+        for n in number_array
+    ]
+
+
 def size_format(number):
     for unit in ['o', 'Kio', 'Mio', 'Gio', 'Tio']:
         if number < 1024.0:
             if number < 10:
-                return "{0:.1f} {1!s}".format(number, unit)
+                return "{:.1f} {}".format(number, unit)
             else:
-                return "{0:.0f} {1!s}".format(number, unit)
+                return "{:.0f} {}".format(number, unit)
         number /= 1024.0
 
 
@@ -15,6 +22,6 @@ def duration_format(duration):
     hours, remainder = divmod(duration.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
     if duration.days > 0:
-        return '{0:d} {1:d}:{2:02d}:{3:02d}'.format(duration.days, hours, minutes, seconds)
+        return '{} {}:{:02d}:{:02d}'.format(duration.days, hours, minutes, seconds)
     else:
-        return '{0:d}:{1:02d}:{2:02d}'.format(hours, minutes, seconds)
+        return '{}:{:02d}:{:02d}'.format(hours, minutes, seconds)

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -58,10 +58,9 @@ class Generate:
         if options.get_bbox:
             try:
                 tilecoord = parse_tilecoord(options.get_bbox)
-                print(
-                    "Tile bounds: [{0:d},{1:d},{2:d},{3:d}]".format(*
-                    gene.layer['grid_ref']['obj'].extent(tilecoord))
-                )
+                print("Tile bounds: [{0:d},{1:d},{2:d},{3:d}]".format(
+                    *gene.layer['grid_ref']['obj'].extent(tilecoord)
+                ))
                 exit()
             except ValueError as e:  # pragma: no cover
                 exit(
@@ -261,7 +260,7 @@ class Generate:
             generated_tiles_file = open(options.generated_tiles_file, 'a')
 
             def do(tile):
-                generated_tiles_file.write('{0!s}\n'.format(tile.tilecoord ))
+                generated_tiles_file.write('{0!s}\n'.format(tile.tilecoord))
                 return tile
             gene.imap(do)
 
@@ -289,7 +288,9 @@ class Generate:
                     elif self.n == 2 * options.time:
                         t2 = datetime.now()
                         d = (t2 - self.t1) / options.time
-                        sys.stdout.write('time: {0:d}\n'.format(((d.days * 24 * 3600 + d.seconds) * 1000000 + d.microseconds)))
+                        sys.stdout.write('time: {0:d}\n'.format(
+                            ((d.days * 24 * 3600 + d.seconds) * 1000000 + d.microseconds)
+                        ))
                     return tile
             gene.imap(LogTime())
 

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -59,14 +59,13 @@ class Generate:
             try:
                 tilecoord = parse_tilecoord(options.get_bbox)
                 print(
-                    "Tile bounds: [%i,%i,%i,%i]" %
-                    gene.layer['grid_ref']['obj'].extent(tilecoord)
+                    "Tile bounds: [{0:d},{1:d},{2:d},{3:d}]".format(*
+                    gene.layer['grid_ref']['obj'].extent(tilecoord))
                 )
                 exit()
             except ValueError as e:  # pragma: no cover
                 exit(
-                    "Tile '%s' is not in the format 'z/x/y' or z/x/y:+n/+n\n%r" %
-                    (options.get_bbox, e)
+                    "Tile '{0!s}' is not in the format 'z/x/y' or z/x/y:+n/+n\n{1!r}".format(options.get_bbox, e)
                 )
 
         if options.get_hash:
@@ -107,8 +106,7 @@ class Generate:
                     gene.set_tilecoords([TileCoord(z, x, y)])
             except ValueError as e:  # pragma: no cover
                 exit(
-                    "Tile '%s' is not in the format 'z/x/y'\n%r" %
-                    (options.get_hash, e)
+                    "Tile '{0!s}' is not in the format 'z/x/y'\n{1!r}".format(options.get_hash, e)
                 )
 
         # At this stage, the tilestream contains metatiles that intersect geometry
@@ -178,13 +176,13 @@ class Generate:
                 if tile is not None and tile.content_type is not None \
                         and tile.content_type.find("image/") != 0:
                     if tile.content_type.find("application/vnd.ogc.se_xml") == 0:
-                        tile.error = "WMS server error: %s" % (
+                        tile.error = "WMS server error: {0!s}".format((
                             self._re_rm_xml_tag.sub(
                                 '', tile.data.decode('utf-8') if PY3 else tile.data
                             )
-                        )
+                        ))
                     else:  # pragma: no cover
-                        tile.error = "%s is not an image format, error: %s" % (
+                        tile.error = "{0!s} is not an image format, error: {1!s}".format(
                             tile.content_type,
                             tile.data
                         )
@@ -252,7 +250,7 @@ class Generate:
 
             if options.time:
                 def log_size(tile):
-                    sys.stdout.write('size: %i\n' % len(tile.data))
+                    sys.stdout.write('size: {0:d}\n'.format(len(tile.data)))
                     return tile
                 gene.imap(log_size)
 
@@ -263,7 +261,7 @@ class Generate:
             generated_tiles_file = open(options.generated_tiles_file, 'a')
 
             def do(tile):
-                generated_tiles_file.write('%s\n' % (tile.tilecoord, ))
+                generated_tiles_file.write('{0!s}\n'.format(tile.tilecoord ))
                 return tile
             gene.imap(do)
 
@@ -291,7 +289,7 @@ class Generate:
                     elif self.n == 2 * options.time:
                         t2 = datetime.now()
                         d = (t2 - self.t1) / options.time
-                        sys.stdout.write('time: %i\n' % ((d.days * 24 * 3600 + d.seconds) * 1000000 + d.microseconds))
+                        sys.stdout.write('time: {0:d}\n'.format(((d.days * 24 * 3600 + d.seconds) * 1000000 + d.microseconds)))
                     return tile
             gene.imap(LogTime())
 
@@ -303,7 +301,7 @@ class Generate:
                 "The tile generation of layer '{}{}' is finish".format(
                     gene.layer['name'],
                     "" if len(dimensions) == 0 or gene.layer['type'] != 'wms'
-                    else " (%s)" % ", ".join(["=".join(d) for d in dimensions.items()])
+                    else " ({0!s})".format(", ".join(["=".join(d) for d in dimensions.items()]))
                 ),
             ]
             if options.role == "master":  # pragma: no cover
@@ -357,10 +355,10 @@ class Generate:
             connection.publish(
                 gene.config['sns']['topic'],
                 "\n".join(sns_message),
-                "Tile generation (%(layer)s - %(role)s)" % {
+                "Tile generation ({layer!s} - {role!s})".format(**{
                     'role': options.role,
                     'layer': gene.layer['name']
-                }
+                })
             )
 
 
@@ -368,12 +366,12 @@ def daemonize():  # pragma: no cover
     try:
         pid = os.fork()
         if pid > 0:
-            print("Daemonize with pid %i." % pid)
+            print("Daemonize with pid {0:d}.".format(pid))
             sys.stderr.write(str(pid))
             # exit parent
             sys.exit(0)
     except OSError as e:
-        exit("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
+        exit("fork #1 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
 
 
 def main():
@@ -419,7 +417,7 @@ def main():
     if options.get_hash is None and options.get_bbox is None and \
             'authorised_user' in gene.config['generation'] and \
             gene.config['generation']['authorised_user'] != getuser():
-        exit('not authorised, authorised user is: %s.' % gene.config['generation']['authorised_user'])
+        exit('not authorised, authorised user is: {0!s}.'.format(gene.config['generation']['authorised_user']))
 
     if options.cache is None:
         options.cache = gene.config['generation']['default_cache']

--- a/tilecloud_chain/mapnik_.py
+++ b/tilecloud_chain/mapnik_.py
@@ -26,7 +26,7 @@ class MapnikDropActionTileStore(MapnikTileStore):
                         self.store.delete_one(Tile(tilecoord))
                 else:
                     self.store.delete_one(tile)
-            logger.info("The tile %s is dropped" % str(tile.tilecoord))
+            logger.info("The tile {0!s} is dropped".format(str(tile.tilecoord)))
             if hasattr(tile, 'metatile'):  # pragma: no cover
                 tile.metatile.elapsed_togenerate -= 1
                 if tile.metatile.elapsed_togenerate == 0 and self.queue_store is not None:

--- a/tilecloud_chain/mapnik_.py
+++ b/tilecloud_chain/mapnik_.py
@@ -26,7 +26,7 @@ class MapnikDropActionTileStore(MapnikTileStore):
                         self.store.delete_one(Tile(tilecoord))
                 else:
                     self.store.delete_one(tile)
-            logger.info("The tile {0!s} is dropped".format(str(tile.tilecoord)))
+            logger.info("The tile {} is dropped".format(str(tile.tilecoord)))
             if hasattr(tile, 'metatile'):  # pragma: no cover
                 tile.metatile.elapsed_togenerate -= 1
                 if tile.metatile.elapsed_togenerate == 0 and self.queue_store is not None:

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -53,7 +53,7 @@ class Server:
         self.filters = {}
         self.max_zoom_seed = {}
 
-        logger.info("Config file: '{0!s}'".format(config_file))
+        logger.info("Config file: '{}'".format(config_file))
         self.tilegeneration = TileGeneration(config_file)
 
         self.expires_hours = self.tilegeneration.config['apache']['expires']
@@ -177,7 +177,7 @@ class Server:
                             datetime.datetime.utcnow() +
                             datetime.timedelta(hours=self.expires_hours)
                         ).isoformat(),
-                        'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
+                        'Cache-Control': "max-age={}".format((3600 * self.expires_hours)),
                         'Access-Control-Allow-Origin': '*',
                         'Access-Control-Allow-Methods': 'GET',
                     }, **kwargs)
@@ -186,7 +186,7 @@ class Server:
             elif len(path) >= 1 and path[0] != 'wmts':  # pragma: no cover
                 return self.error(
                     404,
-                    "Type '{0!s}' don't exists, allows values: 'wmts' or 'static'".format(path[0]),
+                    "Type '{}' don't exists, allows values: 'wmts' or 'static'".format(path[0]),
                     **kwargs
                 )
             path = path[1:]  # remove type
@@ -207,7 +207,7 @@ class Server:
                 if params['LAYER'] in self.layers:
                     layer = self.tilegeneration.layers[params['LAYER']]
                 else:
-                    return self.error(400, "Wrong Layer '{0!s}'".format(params['LAYER']), **kwargs)
+                    return self.error(400, "Wrong Layer '{}'".format(params['LAYER']), **kwargs)
 
                 index = 3
                 dimensions = path[index:index + len(layer['dimensions'])]
@@ -225,7 +225,7 @@ class Server:
                     params['REQUEST'] = 'GetTile'
                     params['TILECOL'] = last[0]
                     if last[1] != layer['extension']:  # pragma: no cover
-                        return self.error(400, "Wrong extention '{0!s}'".format(last[1]), **kwargs)
+                        return self.error(400, "Wrong extention '{}'".format(last[1]), **kwargs)
                 elif len(path) == index + 6:
                     params['REQUEST'] = 'GetFeatureInfo'
                     params['TILECOL'] = path[index + 3]
@@ -244,9 +244,9 @@ class Server:
                 return self.error(400, "Not all required parameters are present", **kwargs)
 
         if params['SERVICE'] != 'WMTS':
-            return self.error(400, "Wrong Service '{0!s}'".format(params['SERVICE']), **kwargs)
+            return self.error(400, "Wrong Service '{}'".format(params['SERVICE']), **kwargs)
         if params['VERSION'] != '1.0.0':
-            return self.error(400, "Wrong Version '{0!s}'".format(params['VERSION']), **kwargs)
+            return self.error(400, "Wrong Version '{}'".format(params['VERSION']), **kwargs)
 
         if params['REQUEST'] == 'GetCapabilities':
             wmtscapabilities_file = self.cache['wmtscapabilities_file']
@@ -258,7 +258,7 @@ class Server:
                         datetime.datetime.utcnow() +
                         datetime.timedelta(hours=self.expires_hours)
                     ).isoformat(),
-                    'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
+                    'Cache-Control': "max-age={}".format((3600 * self.expires_hours)),
                     'Access-Control-Allow-Origin': '*',
                     'Access-Control-Allow-Methods': 'GET',
                 }, **kwargs)
@@ -278,7 +278,7 @@ class Server:
             if params['LAYER'] in self.layers:
                 layer = self.tilegeneration.layers[params['LAYER']]
             else:
-                return self.error(400, "Wrong Layer '{0!s}'".format(params['LAYER']), **kwargs)
+                return self.error(400, "Wrong Layer '{}'".format(params['LAYER']), **kwargs)
 
             for dimension in layer['dimensions']:
                 dimensions.append(
@@ -288,9 +288,9 @@ class Server:
                 )
 
         if params['STYLE'] != layer['wmts_style']:
-            return self.error(400, "Wrong Style '{0!s}'".format(params['STYLE']), **kwargs)
+            return self.error(400, "Wrong Style '{}'".format(params['STYLE']), **kwargs)
         if params['TILEMATRIXSET'] != layer['grid']:
-            return self.error(400, "Wrong TileMatrixSet '{0!s}'".format(params['TILEMATRIXSET']), **kwargs)
+            return self.error(400, "Wrong TileMatrixSet '{}'".format(params['TILEMATRIXSET']), **kwargs)
 
         tile = Tile(TileCoord(
             # TODO fix for matrix_identifier = resolution
@@ -325,13 +325,13 @@ class Server:
                     }), no_cache=True, **kwargs
                 )
             else:  # pragma: no cover
-                return self.error(400, "Layer '{0!s}' not queryable".format(layer['name']), **kwargs)
+                return self.error(400, "Layer '{}' not queryable".format(layer['name']), **kwargs)
 
         if params['REQUEST'] != 'GetTile':
-            return self.error(400, "Wrong Request '{0!s}'".format(params['REQUEST']), **kwargs)
+            return self.error(400, "Wrong Request '{}'".format(params['REQUEST']), **kwargs)
 
         if params['FORMAT'] != layer['mime_type']:
-            return self.error(400, "Wrong Format '{0!s}'".format(params['FORMAT']), **kwargs)
+            return self.error(400, "Wrong Format '{}'".format(params['FORMAT']), **kwargs)
 
         if tile.tilecoord.z > self.max_zoom_seed[layer['name']]:  # pragma: no cover
             return self.forward(
@@ -363,7 +363,7 @@ class Server:
         else:  # pragma: no cover
             return self.error(
                 400,
-                "No store found for layer '{0!s}' and dimensions {1!s}".format(
+                "No store found for layer '{}' and dimensions {}".format(
                     layer['name'], ', '.join(dimensions)
                 ),
                 **kwargs
@@ -377,7 +377,7 @@ class Server:
                     datetime.datetime.utcnow() +
                     datetime.timedelta(hours=self.expires_hours)
                 ).isoformat(),
-                'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
+                'Cache-Control': "max-age={}".format((3600 * self.expires_hours)),
                 'Access-Control-Allow-Origin': '*',
                 'Access-Control-Allow-Methods': 'GET',
             }, **kwargs)
@@ -402,13 +402,13 @@ class Server:
                     datetime.datetime.utcnow() +
                     datetime.timedelta(hours=self.expires_hours)
                 ).isoformat()
-                responce_headers['Cache-Control'] = "max-age={0:d}".format((3600 * self.expires_hours))
+                responce_headers['Cache-Control'] = "max-age={}".format((3600 * self.expires_hours))
                 responce_headers['Access-Control-Allow-Origin'] = '*'
                 responce_headers['Access-Control-Allow-Methods'] = 'GET'
             responce_headers
             return self.responce(responce.content, headers=responce_headers, **kwargs)
         else:  # pragma: no cover
-            message = "The URL '{0!s}' return '{1:d} {2!s}', content:\n{3!s}".format(
+            message = "The URL '{}' return '{} {}', content:\n{}".format(
                 url, responce.status_code, responce.reason, responce.text
             )
             logger.warning(message)

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -53,7 +53,7 @@ class Server:
         self.filters = {}
         self.max_zoom_seed = {}
 
-        logger.info("Config file: '%s'" % config_file)
+        logger.info("Config file: '{0!s}'".format(config_file))
         self.tilegeneration = TileGeneration(config_file)
 
         self.expires_hours = self.tilegeneration.config['apache']['expires']
@@ -73,12 +73,12 @@ class Server:
             def _get(self, path, **kwargs):
                 global s3bucket
                 try:
-                    s3key = s3bucket.key(os.path.join('%(folder)s' % self.cache, path))
+                    s3key = s3bucket.key(os.path.join('{folder!s}'.format(**self.cache), path))
                     responce = s3key.get()
                     return responce.body, responce.headers['Content-Type']
                 except:
                     s3bucket = S3Connection().bucket(self.cache['bucket'])
-                    s3key = s3bucket.key(os.path.join('%(folder)s' % self.cache, path))
+                    s3key = s3bucket.key(os.path.join('{folder!s}'.format(**self.cache), path))
                     responce = s3key.get()
                     return responce.body, responce.headers['Content-Type']
         else:
@@ -177,7 +177,7 @@ class Server:
                             datetime.datetime.utcnow() +
                             datetime.timedelta(hours=self.expires_hours)
                         ).isoformat(),
-                        'Cache-Control': "max-age=%i" % (3600 * self.expires_hours),
+                        'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
                         'Access-Control-Allow-Origin': '*',
                         'Access-Control-Allow-Methods': 'GET',
                     }, **kwargs)
@@ -186,7 +186,7 @@ class Server:
             elif len(path) >= 1 and path[0] != 'wmts':  # pragma: no cover
                 return self.error(
                     404,
-                    "Type '%s' don't exists, allows values: 'wmts' or 'static'" % path[0],
+                    "Type '{0!s}' don't exists, allows values: 'wmts' or 'static'".format(path[0]),
                     **kwargs
                 )
             path = path[1:]  # remove type
@@ -207,7 +207,7 @@ class Server:
                 if params['LAYER'] in self.layers:
                     layer = self.tilegeneration.layers[params['LAYER']]
                 else:
-                    return self.error(400, "Wrong Layer '%s'" % params['LAYER'], **kwargs)
+                    return self.error(400, "Wrong Layer '{0!s}'".format(params['LAYER']), **kwargs)
 
                 index = 3
                 dimensions = path[index:index + len(layer['dimensions'])]
@@ -225,7 +225,7 @@ class Server:
                     params['REQUEST'] = 'GetTile'
                     params['TILECOL'] = last[0]
                     if last[1] != layer['extension']:  # pragma: no cover
-                        return self.error(400, "Wrong extention '%s'" % last[1], **kwargs)
+                        return self.error(400, "Wrong extention '{0!s}'".format(last[1]), **kwargs)
                 elif len(path) == index + 6:
                     params['REQUEST'] = 'GetFeatureInfo'
                     params['TILECOL'] = path[index + 3]
@@ -244,9 +244,9 @@ class Server:
                 return self.error(400, "Not all required parameters are present", **kwargs)
 
         if params['SERVICE'] != 'WMTS':
-            return self.error(400, "Wrong Service '%s'" % params['SERVICE'], **kwargs)
+            return self.error(400, "Wrong Service '{0!s}'".format(params['SERVICE']), **kwargs)
         if params['VERSION'] != '1.0.0':
-            return self.error(400, "Wrong Version '%s'" % params['VERSION'], **kwargs)
+            return self.error(400, "Wrong Version '{0!s}'".format(params['VERSION']), **kwargs)
 
         if params['REQUEST'] == 'GetCapabilities':
             wmtscapabilities_file = self.cache['wmtscapabilities_file']
@@ -258,7 +258,7 @@ class Server:
                         datetime.datetime.utcnow() +
                         datetime.timedelta(hours=self.expires_hours)
                     ).isoformat(),
-                    'Cache-Control': "max-age=%i" % (3600 * self.expires_hours),
+                    'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
                     'Access-Control-Allow-Origin': '*',
                     'Access-Control-Allow-Methods': 'GET',
                 }, **kwargs)
@@ -278,7 +278,7 @@ class Server:
             if params['LAYER'] in self.layers:
                 layer = self.tilegeneration.layers[params['LAYER']]
             else:
-                return self.error(400, "Wrong Layer '%s'" % params['LAYER'], **kwargs)
+                return self.error(400, "Wrong Layer '{0!s}'".format(params['LAYER']), **kwargs)
 
             for dimension in layer['dimensions']:
                 dimensions.append(
@@ -288,9 +288,9 @@ class Server:
                 )
 
         if params['STYLE'] != layer['wmts_style']:
-            return self.error(400, "Wrong Style '%s'" % params['STYLE'], **kwargs)
+            return self.error(400, "Wrong Style '{0!s}'".format(params['STYLE']), **kwargs)
         if params['TILEMATRIXSET'] != layer['grid']:
-            return self.error(400, "Wrong TileMatrixSet '%s'" % params['TILEMATRIXSET'], **kwargs)
+            return self.error(400, "Wrong TileMatrixSet '{0!s}'".format(params['TILEMATRIXSET']), **kwargs)
 
         tile = Tile(TileCoord(
             # TODO fix for matrix_identifier = resolution
@@ -325,13 +325,13 @@ class Server:
                     }), no_cache=True, **kwargs
                 )
             else:  # pragma: no cover
-                return self.error(400, "Layer '%s' not queryable" % layer['name'], **kwargs)
+                return self.error(400, "Layer '{0!s}' not queryable".format(layer['name']), **kwargs)
 
         if params['REQUEST'] != 'GetTile':
-            return self.error(400, "Wrong Request '%s'" % params['REQUEST'], **kwargs)
+            return self.error(400, "Wrong Request '{0!s}'".format(params['REQUEST']), **kwargs)
 
         if params['FORMAT'] != layer['mime_type']:
-            return self.error(400, "Wrong Format '%s'" % params['FORMAT'], **kwargs)
+            return self.error(400, "Wrong Format '{0!s}'".format(params['FORMAT']), **kwargs)
 
         if tile.tilecoord.z > self.max_zoom_seed[layer['name']]:  # pragma: no cover
             return self.forward(
@@ -363,7 +363,7 @@ class Server:
         else:  # pragma: no cover
             return self.error(
                 400,
-                "No store found for layer '%s' and dimensions %s" % (
+                "No store found for layer '{0!s}' and dimensions {1!s}".format(
                     layer['name'], ', '.join(dimensions)
                 ),
                 **kwargs
@@ -377,7 +377,7 @@ class Server:
                     datetime.datetime.utcnow() +
                     datetime.timedelta(hours=self.expires_hours)
                 ).isoformat(),
-                'Cache-Control': "max-age=%i" % (3600 * self.expires_hours),
+                'Cache-Control': "max-age={0:d}".format((3600 * self.expires_hours)),
                 'Access-Control-Allow-Origin': '*',
                 'Access-Control-Allow-Methods': 'GET',
             }, **kwargs)
@@ -402,14 +402,14 @@ class Server:
                     datetime.datetime.utcnow() +
                     datetime.timedelta(hours=self.expires_hours)
                 ).isoformat()
-                responce_headers['Cache-Control'] = "max-age=%i" % (3600 * self.expires_hours)
+                responce_headers['Cache-Control'] = "max-age={0:d}".format((3600 * self.expires_hours))
                 responce_headers['Access-Control-Allow-Origin'] = '*'
                 responce_headers['Access-Control-Allow-Methods'] = 'GET'
             responce_headers
             return self.responce(responce.content, headers=responce_headers, **kwargs)
         else:  # pragma: no cover
-            message = "The URL '%s' return '%i %s', content:\n%s" % (
-                url, responce.status_code, responce.reason, responce.text,
+            message = "The URL '{0!s}' return '{1:d} {2!s}', content:\n{3!s}".format(
+                url, responce.status_code, responce.reason, responce.text
             )
             logger.warning(message)
             return self.error(502, message=message, **kwargs)

--- a/tilecloud_chain/tests/__init__.py
+++ b/tilecloud_chain/tests/__init__.py
@@ -33,17 +33,17 @@ class CompareCase(TestCase):
             if test[0] != 'PASS...':
                 try:
                     if regex:
-                        self.assertRegexpMatches(test[1].strip(), '^%s$' % test[0].strip())
+                        self.assertRegexpMatches(test[1].strip(), '^{0!s}$'.format(test[0].strip()))
                     else:
                         self.assertEqual(test[0].strip(), test[1].strip())
                 except AssertionError as e:
                     for i in range(max(0, n - 20), min(len(result), n + 21)):
                         if i == n:
-                            print("> %i %s" % (i, result[i]))
-                            log.info("> %i %s" % (i, result[i]))
+                            print("> {0:d} {1!s}".format(i, result[i]))
+                            log.info("> {0:d} {1!s}".format(i, result[i]))
                         else:
-                            print("  %i %s" % (i, result[i]))
-                            log.info("  %i %s" % (i, result[i]))
+                            print("  {0:d} {1!s}".format(i, result[i]))
+                            log.info("  {0:d} {1!s}".format(i, result[i]))
                     raise e
         self.assertEqual(len(expected), len(result), repr(result))
 

--- a/tilecloud_chain/tests/__init__.py
+++ b/tilecloud_chain/tests/__init__.py
@@ -33,17 +33,17 @@ class CompareCase(TestCase):
             if test[0] != 'PASS...':
                 try:
                     if regex:
-                        self.assertRegexpMatches(test[1].strip(), '^{0!s}$'.format(test[0].strip()))
+                        self.assertRegexpMatches(test[1].strip(), '^{}$'.format(test[0].strip()))
                     else:
                         self.assertEqual(test[0].strip(), test[1].strip())
                 except AssertionError as e:
                     for i in range(max(0, n - 20), min(len(result), n + 21)):
                         if i == n:
-                            print("> {0:d} {1!s}".format(i, result[i]))
-                            log.info("> {0:d} {1!s}".format(i, result[i]))
+                            print("> {} {}".format(i, result[i]))
+                            log.info("> {} {}".format(i, result[i]))
                         else:
-                            print("  {0:d} {1!s}".format(i, result[i]))
-                            log.info("  {0:d} {1!s}".format(i, result[i]))
+                            print("  {} {}".format(i, result[i]))
+                            log.info("  {} {}".format(i, result[i]))
                     raise e
         self.assertEqual(len(expected), len(result), repr(result))
 

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -1502,7 +1502,7 @@ MapCacheAlias /mapcache "%s"
             cmd='.build/venv/bin/generate_controller --apache -c tilegeneration/test-serve.yaml',
             main_func=controller.main,
             expected=[['tiles.conf', u"""
-MapCacheAlias /mapcache "{0!s}"
+MapCacheAlias /mapcache "{}"
 """.format((os.path.abspath('mapcache.xml')))]])
 
     @attr(general=True)

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -1502,8 +1502,8 @@ MapCacheAlias /mapcache "%s"
             cmd='.build/venv/bin/generate_controller --apache -c tilegeneration/test-serve.yaml',
             main_func=controller.main,
             expected=[['tiles.conf', u"""
-MapCacheAlias /mapcache "%s"
-""" % (os.path.abspath('mapcache.xml'))]])
+MapCacheAlias /mapcache "{0!s}"
+""".format((os.path.abspath('mapcache.xml')))]])
 
     @attr(general=True)
     def test_apache_s3(self):

--- a/tilecloud_chain/tests/test_copy.py
+++ b/tilecloud_chain/tests/test_copy.py
@@ -35,7 +35,7 @@ class TestGenerate(CompareCase):
 
         for d in ('-d', '-q', '-v'):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_copy %s -c tilegeneration/test-copy.yaml src dst' % d,
+                cmd='.build/venv/bin/generate_copy {0!s} -c tilegeneration/test-copy.yaml src dst'.format(d),
                 main_func=copy_.main,
                 regex=True,
                 expected="""The tile copy of layer 'point_hash' is finish
@@ -76,7 +76,7 @@ image%2Fpng&REQUEST=GetMap&HEIGHT=256&WIDTH=256&VERSION=1.1.1&BBOX=\
             self.assertEqual(statinfo.st_size, 755)
 
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_process %s -c tilegeneration/test-copy.yaml --cache src optipng' % d,
+                cmd='.build/venv/bin/generate_process {0!s} -c tilegeneration/test-copy.yaml --cache src optipng'.format(d),
                 main_func=copy_.process,
                 regex=True,
                 expected="""The tile process of layer 'point_hash' is finish

--- a/tilecloud_chain/tests/test_copy.py
+++ b/tilecloud_chain/tests/test_copy.py
@@ -76,7 +76,8 @@ image%2Fpng&REQUEST=GetMap&HEIGHT=256&WIDTH=256&VERSION=1.1.1&BBOX=\
             self.assertEqual(statinfo.st_size, 755)
 
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_process {0!s} -c tilegeneration/test-copy.yaml --cache src optipng'.format(d),
+                cmd='.build/venv/bin/generate_process {0!s} -c '
+                    'tilegeneration/test-copy.yaml --cache src optipng'.format(d),
                 main_func=copy_.process,
                 regex=True,
                 expected="""The tile process of layer 'point_hash' is finish

--- a/tilecloud_chain/tests/test_copy.py
+++ b/tilecloud_chain/tests/test_copy.py
@@ -35,7 +35,7 @@ class TestGenerate(CompareCase):
 
         for d in ('-d', '-q', '-v'):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_copy {0!s} -c tilegeneration/test-copy.yaml src dst'.format(d),
+                cmd='.build/venv/bin/generate_copy {} -c tilegeneration/test-copy.yaml src dst'.format(d),
                 main_func=copy_.main,
                 regex=True,
                 expected="""The tile copy of layer 'point_hash' is finish
@@ -45,7 +45,7 @@ Nb dropped tiles: 0
 Total time: 0:00:[0-9][0-9]
 Total size: 10 o
 Time per tile: [0-9]+ ms
-Size per tile: 10 o
+Size per tile: 10(.0)? o
 
 """ if d != '-q' else '',
                 empty_err=True)
@@ -76,7 +76,7 @@ image%2Fpng&REQUEST=GetMap&HEIGHT=256&WIDTH=256&VERSION=1.1.1&BBOX=\
             self.assertEqual(statinfo.st_size, 755)
 
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_process {0!s} -c '
+                cmd='.build/venv/bin/generate_process {} -c '
                     'tilegeneration/test-copy.yaml --cache src optipng'.format(d),
                 main_func=copy_.process,
                 regex=True,
@@ -87,7 +87,7 @@ Nb dropped tiles: 0
 Total time: 0:00:[0-9][0-9]
 Total size: 103 o
 Time per tile: [0-9]+ ms
-Size per tile: 103 o
+Size per tile: 103(.0)? o
 
 """ if d != '-q' else '',
                 empty_err=True)

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -32,7 +32,7 @@ class TestGenerate(CompareCase):
     def test_get_hash(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 '
+                cmd='.build/venv/bin/generate_tiles {} --get-hash 4/0/0 '
                     '-c tilegeneration/test.yaml -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0:+8/+8
@@ -52,7 +52,7 @@ class TestGenerate(CompareCase):
     def test_get_wrong_hash(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 0/7/5 '
+                cmd='.build/venv/bin/generate_tiles {} --get-hash 0/7/5 '
                     '-c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Error: image is not uniform.""")
@@ -63,19 +63,19 @@ class TestGenerate(CompareCase):
     def test_get_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test.yaml --get-bbox 4/4/4 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test.yaml --get-bbox 4/4/4:+1/+1 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test.yaml --get-bbox 4/4/4:+2/+2 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,342320,427680,344880]
@@ -88,7 +88,7 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '--get-hash 4/0/0 -c tilegeneration/test.yaml -l mapnik'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
@@ -104,7 +104,7 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '--get-hash 4/0/0 -c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
@@ -119,7 +119,7 @@ class TestGenerate(CompareCase):
     def test_test_all(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1'.format(d),
+                cmd='.build/venv/bin/generate_tiles {} -c tilegeneration/test-nosns.yaml -t 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -274,7 +274,7 @@ Size per tile: [79][0-9][0-9] o
     def test_zoom_identifier(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -297,7 +297,7 @@ Size per tile: 389 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -320,7 +320,7 @@ Size per tile: 517 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 2'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -385,7 +385,7 @@ Total time: [0-9]+:[0-9][0-9]:[0-9][0-9]
     def test_zoom(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l point_hash --zoom 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -414,7 +414,7 @@ Size per tile: 4[0-9][0-9] o
     def test_zoom_range(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l point_hash --zoom 1-3'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -445,7 +445,7 @@ Size per tile: 4[0-9][0-9] o
     def test_no_zoom(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash'.format(d),
+                cmd='.build/venv/bin/generate_tiles {} -c tilegeneration/test-nosns.yaml -l point_hash'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -543,7 +543,7 @@ Size per tile: 4[0-9][0-9] o
     def test_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l polygon -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -612,7 +612,7 @@ Size per tile: [89][0-9][0-9] o
             )
 
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l all -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -639,7 +639,7 @@ Size per tile: [89][0-9][0-9] o
     def test_hash_generation(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l point_hash -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -669,7 +669,7 @@ Size per tile: [45][0-9][0-9] o
     def test_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l mapnik -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -696,7 +696,7 @@ Size per tile: 823 o
     def test_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l mapnik_grid -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -741,7 +741,7 @@ Size per tile: 385 o
     def test_mapnik_grid_drop(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -l mapnik_grid_drop -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
@@ -767,7 +767,7 @@ Size per tile: 384 o
     def test_not_authorised_user(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-authorised.yaml'.format(d),
                 main_func=generate.main,
                 expected="""not authorised, authorised user is: www-data.""")
@@ -778,7 +778,7 @@ Size per tile: 384 o
     def test_verbose(self, l):
         for d in ('-d', ''):
             self.run_cmd(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test-nosns.yaml -t 2 -v -l polygon'.format(d),
                 main_func=generate.main
             )
@@ -788,7 +788,7 @@ Size per tile: 384 o
     def test_time(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test.yaml --time 2 -l polygon'.format(d),
                 main_func=generate.main,
                 expected="""size: 770
@@ -807,7 +807,7 @@ size: 862
     def test_time_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} '
+                cmd='.build/venv/bin/generate_tiles {} '
                     '-c tilegeneration/test.yaml --time 2 -l all'.format(d),
                 main_func=generate.main,
                 expected="""size: 1010
@@ -961,7 +961,7 @@ Size per tile: [45][0-9][0-9] o
     def test_multy(self):
         for d in ('-v', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-multidim.yaml'.format(d),
+                cmd='.build/venv/bin/generate_tiles {} -c tilegeneration/test-multidim.yaml'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/multi/default/%s/swissgrid/%i/%i/%i.png',

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -32,7 +32,8 @@ class TestGenerate(CompareCase):
     def test_get_hash(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l point'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 '
+                    '-c tilegeneration/test.yaml -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0:+8/+8
         empty_metatile_detection:
@@ -51,7 +52,8 @@ class TestGenerate(CompareCase):
     def test_get_wrong_hash(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 0/7/5 -c tilegeneration/test.yaml -l all'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 0/7/5 '
+                    '-c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Error: image is not uniform.""")
         l.check()
@@ -61,17 +63,20 @@ class TestGenerate(CompareCase):
     def test_get_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4 -l point'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test.yaml --get-bbox 4/4/4 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4:+1/+1 -l point'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test.yaml --get-bbox 4/4/4:+1/+1 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4:+2/+2 -l point'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test.yaml --get-bbox 4/4/4:+2/+2 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,342320,427680,344880]
 """)
@@ -83,7 +88,8 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l mapnik'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '--get-hash 4/0/0 -c tilegeneration/test.yaml -l mapnik'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
         empty_tile_detection:
@@ -98,7 +104,8 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l all'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '--get-hash 4/0/0 -c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
         empty_tile_detection:
@@ -267,13 +274,13 @@ Size per tile: [79][0-9][0-9] o
     def test_zoom_identifier(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
                 tiles=[
-                    ('polygon2', '1', 585, 429)
-                ],
+                    ('polygon2', '1', 585, 429)],
                 regex=True,
                 expected="""The tile generation of layer 'polygon2 \(DATE=2012\)' is finish
 Nb generated metatiles: 1
@@ -290,13 +297,13 @@ Size per tile: 389 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 1'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
                 tiles=[
-                    ('polygon2', '0_2', 2929, 2148)
-                ],
+                    ('polygon2', '0_2', 2929, 2148)],
                 regex=True,
                 expected="""The tile generation of layer 'polygon2 \(DATE=2012\)' is finish
 Nb generated metatiles: 1
@@ -313,13 +320,13 @@ Size per tile: 517 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 2'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 2'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
                 tiles=[
-                    ('polygon2', '0_1', 5859, 4296)
-                ],
+                    ('polygon2', '0_1', 5859, 4296)],
                 regex=True,
                 expected="""The tile generation of layer 'polygon2 \(DATE=2012\)' is finish
 Nb generated metatiles: 1
@@ -378,13 +385,13 @@ Total time: [0-9]+:[0-9][0-9]:[0-9][0-9]
     def test_zoom(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l point_hash --zoom 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
                 tiles=[
-                    ('point_hash', 1, 11, 14), ('point_hash', 1, 15, 8)
-                ],
+                    ('point_hash', 1, 11, 14), ('point_hash', 1, 15, 8)],
                 regex=True,
                 expected="""The tile generation of layer 'point_hash \(DATE=2012\)' is finish
 Nb generated metatiles: 1
@@ -407,15 +414,15 @@ Size per tile: 4[0-9][0-9] o
     def test_zoom_range(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1-3'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l point_hash --zoom 1-3'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
                 tiles=[
                     ('point_hash', 1, 11, 14), ('point_hash', 1, 15, 8),
                     ('point_hash', 2, 29, 35), ('point_hash', 2, 39, 21),
-                    ('point_hash', 3, 58, 70), ('point_hash', 3, 78, 42),
-                ],
+                    ('point_hash', 3, 58, 70), ('point_hash', 3, 78, 42)],
                 regex=True,
                 expected="""The tile generation of layer 'point_hash \(DATE=2012\)' is finish
 Nb generated metatiles: 9
@@ -536,7 +543,8 @@ Size per tile: 4[0-9][0-9] o
     def test_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l polygon -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l polygon -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/polygon/default/2012/swissgrid_5/0/%i/%i.png',
@@ -556,8 +564,9 @@ Size per tile: [69][0-9][0-9] o
             )
 
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l polygon -z 0'
-                ' -b 550000 170000 560000 180000' % d,
+                cmd='.build/venv/bin/generate_tiles %s '
+                    '-c tilegeneration/test-nosns.yaml -l polygon -z 0'
+                    ' -b 550000 170000 560000 180000' % d,
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/polygon/default/2012/swissgrid_5/0/%i/%i.png',
@@ -579,8 +588,9 @@ Size per tile: [89][0-9][0-9] o
             )
 
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l polygon -z 0'
-                ' -b 550000.0 170000.0 560000.0 180000.0' % d,
+                cmd='.build/venv/bin/generate_tiles %s '
+                    '-c tilegeneration/test-nosns.yaml -l polygon -z 0'
+                    ' -b 550000.0 170000.0 560000.0 180000.0' % d,
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/polygon/default/2012/swissgrid_5/0/%i/%i.png',
@@ -602,13 +612,13 @@ Size per tile: [89][0-9][0-9] o
             )
 
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l all -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l all -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/all/default/2012/swissgrid_5/0/%i/%i.png',
                 tiles=[
-                    (6, 5), (7, 5)
-                ],
+                    (6, 5), (7, 5)],
                 regex=True,
                 expected="""The tile generation of layer 'all \(DATE=2012\)' is finish
 Nb generated tiles: 2
@@ -629,13 +639,13 @@ Size per tile: [89][0-9][0-9] o
     def test_hash_generation(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l point_hash -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/point_hash/default/2012/swissgrid_5/0/%i/%i.png',
                 tiles=[
-                    (5, 7), (7, 4)
-                ],
+                    (5, 7), (7, 4)],
                 regex=True,
                 expected="""The tile generation of layer 'point_hash \(DATE=2012\)' is finish
 Nb generated metatiles: 1
@@ -659,7 +669,8 @@ Size per tile: [45][0-9][0-9] o
     def test_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l mapnik -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik/default/2012/swissgrid_5/0/%i/%i.png',
@@ -685,7 +696,8 @@ Size per tile: 823 o
     def test_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik_grid -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l mapnik_grid -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik_grid/default/2012/swissgrid_5/0/%i/%i.json',
@@ -729,7 +741,8 @@ Size per tile: 385 o
     def test_mapnik_grid_drop(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik_grid_drop -z 0'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -l mapnik_grid_drop -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik_grid_drop/default/2012/swissgrid_5/0/%i/%i.json',
@@ -754,7 +767,8 @@ Size per tile: 384 o
     def test_not_authorised_user(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-authorised.yaml'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-authorised.yaml'.format(d),
                 main_func=generate.main,
                 expected="""not authorised, authorised user is: www-data.""")
         l.check()
@@ -764,7 +778,8 @@ Size per tile: 384 o
     def test_verbose(self, l):
         for d in ('-d', ''):
             self.run_cmd(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 2 -v -l polygon'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test-nosns.yaml -t 2 -v -l polygon'.format(d),
                 main_func=generate.main
             )
         l.check()
@@ -773,7 +788,8 @@ Size per tile: 384 o
     def test_time(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --time 2 -l polygon'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test.yaml --time 2 -l polygon'.format(d),
                 main_func=generate.main,
                 expected="""size: 770
 size: 862
@@ -791,7 +807,8 @@ size: 862
     def test_time_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --time 2 -l all'.format(d),
+                cmd='.build/venv/bin/generate_tiles {0!s} '
+                    '-c tilegeneration/test.yaml --time 2 -l all'.format(d),
                 main_func=generate.main,
                 expected="""size: 1010
 size: 1010

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -32,7 +32,7 @@ class TestGenerate(CompareCase):
     def test_get_hash(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s --get-hash 4/0/0 -c tilegeneration/test.yaml -l point' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0:+8/+8
         empty_metatile_detection:
@@ -51,7 +51,7 @@ class TestGenerate(CompareCase):
     def test_get_wrong_hash(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles %s --get-hash 0/7/5 -c tilegeneration/test.yaml -l all' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 0/7/5 -c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Error: image is not uniform.""")
         l.check()
@@ -61,17 +61,17 @@ class TestGenerate(CompareCase):
     def test_get_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test.yaml --get-bbox 4/4/4 -l point' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test.yaml --get-bbox 4/4/4:+1/+1 -l point' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4:+1/+1 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,343600,426400,344880]
 """)
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test.yaml --get-bbox 4/4/4:+2/+2 -l point' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --get-bbox 4/4/4:+2/+2 -l point'.format(d),
                 main_func=generate.main,
                 expected="""Tile bounds: [425120,342320,427680,344880]
 """)
@@ -83,7 +83,7 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s --get-hash 4/0/0 -c tilegeneration/test.yaml -l mapnik' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l mapnik'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
         empty_tile_detection:
@@ -98,7 +98,7 @@ class TestGenerate(CompareCase):
     def test_hash_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s --get-hash 4/0/0 -c tilegeneration/test.yaml -l all' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} --get-hash 4/0/0 -c tilegeneration/test.yaml -l all'.format(d),
                 main_func=generate.main,
                 expected="""Tile: 4/0/0
         empty_tile_detection:
@@ -112,7 +112,7 @@ class TestGenerate(CompareCase):
     def test_test_all(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -t 1' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -267,7 +267,7 @@ Size per tile: [79][0-9][0-9] o
     def test_zoom_identifier(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
@@ -290,7 +290,7 @@ Size per tile: 389 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 1' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
@@ -313,7 +313,7 @@ Size per tile: 517 o
 """,
             )
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 2' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 1 -l polygon2 -z 2'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_01/%s/%i/%i.png',
@@ -378,7 +378,7 @@ Total time: [0-9]+:[0-9][0-9]:[0-9][0-9]
     def test_zoom(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -407,7 +407,7 @@ Size per tile: 4[0-9][0-9] o
     def test_zoom_range(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1-3' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash --zoom 1-3'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -438,7 +438,7 @@ Size per tile: 4[0-9][0-9] o
     def test_no_zoom(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l point_hash' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/%s/default/2012/swissgrid_5/%i/%i/%i.png',
@@ -536,7 +536,7 @@ Size per tile: 4[0-9][0-9] o
     def test_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l polygon -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l polygon -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/polygon/default/2012/swissgrid_5/0/%i/%i.png',
@@ -602,7 +602,7 @@ Size per tile: [89][0-9][0-9] o
             )
 
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l all -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l all -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/all/default/2012/swissgrid_5/0/%i/%i.png',
@@ -629,7 +629,7 @@ Size per tile: [89][0-9][0-9] o
     def test_hash_generation(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l point_hash -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l point_hash -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/point_hash/default/2012/swissgrid_5/0/%i/%i.png',
@@ -659,7 +659,7 @@ Size per tile: [45][0-9][0-9] o
     def test_mapnik(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l mapnik -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik/default/2012/swissgrid_5/0/%i/%i.png',
@@ -685,7 +685,7 @@ Size per tile: 823 o
     def test_mapnik_grid(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l mapnik_grid -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik_grid -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik_grid/default/2012/swissgrid_5/0/%i/%i.json',
@@ -729,7 +729,7 @@ Size per tile: 385 o
     def test_mapnik_grid_drop(self, l):
         for d in ('-d', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -l mapnik_grid_drop -z 0' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -l mapnik_grid_drop -z 0'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/mapnik_grid_drop/default/2012/swissgrid_5/0/%i/%i.json',
@@ -754,7 +754,7 @@ Size per tile: 384 o
     def test_not_authorised_user(self, l):
         for d in ('-d', '-q'):
             self.assert_cmd_exit_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-authorised.yaml' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-authorised.yaml'.format(d),
                 main_func=generate.main,
                 expected="""not authorised, authorised user is: www-data.""")
         l.check()
@@ -764,7 +764,7 @@ Size per tile: 384 o
     def test_verbose(self, l):
         for d in ('-d', ''):
             self.run_cmd(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-nosns.yaml -t 2 -v -l polygon' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-nosns.yaml -t 2 -v -l polygon'.format(d),
                 main_func=generate.main
             )
         l.check()
@@ -773,7 +773,7 @@ Size per tile: 384 o
     def test_time(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test.yaml --time 2 -l polygon' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --time 2 -l polygon'.format(d),
                 main_func=generate.main,
                 expected="""size: 770
 size: 862
@@ -791,7 +791,7 @@ size: 862
     def test_time_layer_bbox(self, l):
         for d in ('-d', ''):
             self.assert_cmd_equals(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test.yaml --time 2 -l all' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test.yaml --time 2 -l all'.format(d),
                 main_func=generate.main,
                 expected="""size: 1010
 size: 1010
@@ -944,7 +944,7 @@ Size per tile: [45][0-9][0-9] o
     def test_multy(self):
         for d in ('-v', ''):
             self.assert_tiles_generated(
-                cmd='.build/venv/bin/generate_tiles %s -c tilegeneration/test-multidim.yaml' % d,
+                cmd='.build/venv/bin/generate_tiles {0!s} -c tilegeneration/test-multidim.yaml'.format(d),
                 main_func=generate.main,
                 directory="/tmp/tiles/",
                 tiles_pattern='1.0.0/multi/default/%s/swissgrid/%i/%i/%i.png',

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1041,7 +1041,7 @@ Size per tile: 4[0-9][0-9] o
             for key, value in p_headers:
                 headers[key] = value
         result = serve({
-            'QUERY_STRING': '&'.join(['{0!s}={1!s}'.format(*item) for item in {
+            'QUERY_STRING': '&'.join(['{}={}'.format(*item) for item in {
                 'Service': 'WMTS',
                 'Version': '1.0.0',
                 'Request': 'GetFeatureInfo',

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1041,7 +1041,7 @@ Size per tile: 4[0-9][0-9] o
             for key, value in p_headers:
                 headers[key] = value
         result = serve({
-            'QUERY_STRING': '&'.join(['%s=%s' % item for item in {
+            'QUERY_STRING': '&'.join(['{0!s}={1!s}'.format(*item) for item in {
                 'Service': 'WMTS',
                 'Version': '1.0.0',
                 'Request': 'GetFeatureInfo',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:tilecloud-chain?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:tilecloud-chain?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)